### PR TITLE
Support cypress dashboard.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,12 @@
 FROM cypress/included:8.5.0
+
+WORKDIR /app
+
 RUN npm install @4tw/cypress-drag-drop @testing-library/cypress cypress-file-upload axios luxon
+
 ENV CYPRESS_CI=1
-ENTRYPOINT ["cypress", "run", "-q"]
+ENV LC_ALL="de_CH.UTF-8"
+ENV TZ=Europe/Zurich
+
+COPY entrypoint.sh /app/entrypoint.sh
+ENTRYPOINT ["/app/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -14,3 +14,30 @@ Your also have an env variable named `CYPRESS_CI` set to `1`.
 ## entrypoint
 
 The entrypoint is set to `cypress run -q`. The `-q` is useful to have less clutter on the CI in the output.
+
+
+## Cypress Dashboard
+
+Example `docker-compose.yml` for using Cypress Dashboard for storing
+recordings.
+
+```yml
+services:
+  cypress:
+    image: 4teamwork/cypress
+    environment:
+      - CYPRESS_baseUrl=http://external-frontend:80
+      - NO_COLOR=1
+      - TERM=dumb
+      - CYPRESS_RECORD_KEY=XXXX
+      - CYPRESS_PROJECT_ID=XXXX
+      - CYPRESS_VIDEO=true
+      - COMMIT_INFO_MESSAGE
+      - COMMIT_INFO_REMOTE
+      - COMMIT_INFO_BRANCH
+      - COMMIT_INFO_SHA
+      - COMMIT_INFO_AUTHOR
+      - COMMIT_INFO_EMAIL
+```
+
+When `CYPRESS_RECORD_KEY` is not empty, cypress will be started with the `--record` option.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -o errexit
+
+RECORD=""
+if [[ "$CYPRESS_RECORD_KEY" -ne "" ]]; then
+    RECORD=" --record"
+fi
+
+if [[ $# -eq 0 ]]; then
+    cypress run -q $RECORD
+else
+    eval "$@"
+fi


### PR DESCRIPTION
Cypress dashboard is supported by automatically using the cypress `--record` argument when the environment variable `CYPRESS_RECORD_KEY` is set.

Also includes timezone setting from the DLS project.