### PR TITLE
Fix bash script problem.

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,7 +3,7 @@
 set -o errexit
 
 RECORD=""
-if [[ "$CYPRESS_RECORD_KEY" -ne "" ]]; then
+if [[ "$CYPRESS_RECORD_KEY" != "" ]]; then
     RECORD=" --record"
 fi
 


### PR DESCRIPTION
When the CYPRESS_RECORD_KEY contains a real key with "-", it did not work anymore. The reason is probably that I'm not good enough in writing bash scripts.

The problem was:
```
/app/entrypoint.sh: line 6: [[: 83a4d487: value too great for base (error token is "83a4d487")
```