### PR TITLE
Revert using app workdir in Docker.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,10 @@
 FROM cypress/included:8.5.0
 
-WORKDIR /app
-
 RUN npm install @4tw/cypress-drag-drop @testing-library/cypress cypress-file-upload axios luxon
 
 ENV CYPRESS_CI=1
 ENV LC_ALL="de_CH.UTF-8"
 ENV TZ=Europe/Zurich
 
-COPY entrypoint.sh /app/entrypoint.sh
-ENTRYPOINT ["/app/entrypoint.sh"]
+COPY entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
In a previous change (https://github.com/4teamwork/cypress-docker/pull/2) I started using the /app folder because that is best practice. But it seems to not work properly with the way the base image works; tests are failing. So I'm reverting it back to the original state which works.