### PR TITLE
No longer run cypress as root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,10 +9,12 @@ RUN npm install @4tw/cypress-drag-drop @testing-library/cypress cypress-file-upl
 
 RUN addgroup --system cypress \
     && adduser --system --ingroup cypress cypress
+RUN mkdir -p /app/test
 
 ENV CYPRESS_CI=1
 ENV LC_ALL="de_CH.UTF-8"
 ENV TZ=Europe/Zurich
 
 COPY entrypoint.sh /entrypoint.sh
+
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
 FROM cypress/included:10.3.1
 
+RUN apt-get -y install gosu locales && \
+    sed -i '/de_CH.UTF-8/s/^# //g' /etc/locale.gen && \
+    locale-gen
+
 WORKDIR /app
 RUN npm install @4tw/cypress-drag-drop @testing-library/cypress cypress-file-upload axios luxon
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,9 @@ FROM cypress/included:10.3.1
 WORKDIR /app
 RUN npm install @4tw/cypress-drag-drop @testing-library/cypress cypress-file-upload axios luxon
 
+RUN addgroup --system cypress \
+    && adduser --system --ingroup cypress cypress
+
 ENV CYPRESS_CI=1
 ENV LC_ALL="de_CH.UTF-8"
 ENV TZ=Europe/Zurich

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ It installs additional testing libraries:
 - axios
 - luxon
 
-Your also have an env variable named `CYPRESS_CI` set to `1`.
+You also have an env variable named `CYPRESS_CI` set to `1`.
 
 ## entrypoint
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,6 +7,8 @@ if [[ "$CYPRESS_RECORD_KEY" != "" ]]; then
     RECORD=" --record"
 fi
 
+chown cypress:cypress /app/test
+
 if [[ $# -eq 0 ]]; then
     gosu cypress cypress run -q $RECORD
 else

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,7 +8,7 @@ if [[ "$CYPRESS_RECORD_KEY" != "" ]]; then
 fi
 
 if [[ $# -eq 0 ]]; then
-    cypress run -q $RECORD
+    gosu cypress cypress run -q $RECORD
 else
-    eval "$@"
+    gosu cypress eval "$@"
 fi


### PR DESCRIPTION
Run cypress as cypress user. This should fix jenkins cleanup of temporary folders.

- provide folder with correct permissions for volume mount at `/app/test/`
- fix locales
- a test-run with a temporary tag to verify this still works is available at https://ci.4teamwork.ch/builds/518983/tasks/991629

after a merge do:
- [x] create a tag `10.3.1-1` on docker hub
- [x] drop old temporary tags
- [x] switch https://github.com/4teamwork/ris-publisher to new tag